### PR TITLE
KAPI-10: Add war log endpoint

### DIFF
--- a/src/main/kotlin/tech/ixirsii/klash/client/ClashAPI.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/client/ClashAPI.kt
@@ -56,6 +56,7 @@ import java.io.IOException
 /**
  * Clash of Clans API client.
  *
+ * @property token Clash of Clans API token for authenticating requests.
  * @author Ixirsii <ixirsii@ixirsii.tech>
  */
 class ClashAPI(private val token: String) : Logging by LoggingImpl<ClashAPI>() {
@@ -149,13 +150,13 @@ class ClashAPI(private val token: String) : Logging by LoggingImpl<ClashAPI>() {
                 val error: Either<ClashAPIError, ClientError> = deserialize(response.body?.string() ?: "")
 
                 when (response.code) {
-                    400 -> error.flatMap { ClashAPIError.BadRequest(response.message, it).left() }
-                    403 -> error.flatMap { ClashAPIError.Forbidden(response.message, it).left() }
-                    404 -> error.flatMap { ClashAPIError.NotFound(response.message, it).left() }
-                    429 -> error.flatMap { ClashAPIError.TooManyRequests(response.message, it).left() }
-                    500 -> error.flatMap { ClashAPIError.InternalServerError(response.message, it).left() }
-                    503 -> error.flatMap { ClashAPIError.ServiceUnavailable(response.message, it).left() }
-                    else -> error.flatMap { ClashAPIError.Unknown(response.message, it).left() }
+                    400 -> error.flatMap { ClashAPIError.ClientError.BadRequest(response.message, it).left() }
+                    403 -> error.flatMap { ClashAPIError.ClientError.Forbidden(response.message, it).left() }
+                    404 -> error.flatMap { ClashAPIError.ClientError.NotFound(response.message, it).left() }
+                    429 -> error.flatMap { ClashAPIError.ClientError.TooManyRequests(response.message, it).left() }
+                    500 -> error.flatMap { ClashAPIError.ClientError.InternalServerError(response.message, it).left() }
+                    503 -> error.flatMap { ClashAPIError.ClientError.ServiceUnavailable(response.message, it).left() }
+                    else -> error.flatMap { ClashAPIError.ClientError.Unknown(response.message, it).left() }
                 }
             }
         }

--- a/src/main/kotlin/tech/ixirsii/klash/client/ClashAPI.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/client/ClashAPI.kt
@@ -48,7 +48,9 @@ import tech.ixirsii.klash.error.ClashAPIError
 import tech.ixirsii.klash.logging.Logging
 import tech.ixirsii.klash.logging.LoggingImpl
 import tech.ixirsii.klash.types.cwl.ClanWarLeagueGroup
+import tech.ixirsii.klash.types.error.ClientError
 import tech.ixirsii.klash.types.war.War
+import tech.ixirsii.klash.types.war.WarLog
 import java.io.IOException
 
 /**
@@ -100,6 +102,20 @@ class ClashAPI(private val token: String) : Logging by LoggingImpl<ClashAPI>() {
         return response.map { either -> either.flatMap { deserialize<War>(it.body?.string() ?: "") } }
     }
 
+    fun warLog(
+        tag: String,
+        limit: Int? = null,
+        after: String? = null,
+        before: String? = null,
+    ): Mono<Either<ClashAPIError, WarLog>> {
+        log.trace("Getting war log for clan {}", tag)
+
+        val endpoint = "/clans/%23$tag/warlog${paginationQueryParameters(limit, after, before)}"
+        val response: Mono<Either<ClashAPIError, Response>> = get(endpoint)
+
+        return response.map { either -> either.flatMap { deserialize<WarLog>(it.body?.string() ?: "") } }
+    }
+
     /* *************************************** Private utility functions **************************************** */
 
     /**
@@ -111,38 +127,38 @@ class ClashAPI(private val token: String) : Logging by LoggingImpl<ClashAPI>() {
      * @return [Request.Builder] with the authorization header set.
      */
     private fun baseRequest(suffix: String): Request.Builder {
-        return Request.Builder()
-            .header("Authorization", "Bearer $token")
-            .url(URL + API_VERSION + suffix)
+        return Request.Builder().header("Authorization", "Bearer $token").url(URL + API_VERSION + suffix)
     }
 
     /**
      * Check the response for errors.
      *
-     * @param response HTTP response.
+     * @param responseMono HTTP response.
      * @return [Either.Right] with the response if successful, [Either.Left] with an error otherwise.
      */
-    private fun checkResponse(response: Mono<Response>): Mono<Either<ClashAPIError, Response>> = response.map {
-        log.trace("Checking response {}", it)
+    private fun checkResponse(responseMono: Mono<Response>): Mono<Either<ClashAPIError, Response>> =
+        responseMono.map { response ->
+            log.trace("Checking response {}", response)
 
-        if (it.isSuccessful) {
-            log.debug("Received successful response: {}", it)
+            if (response.isSuccessful) {
+                log.debug("Received successful response: {}", response)
 
-            it.right()
-        } else {
-            log.warn("Received error response: {} {}", it.code, it.message)
+                response.right()
+            } else {
+                log.warn("Received error response: {} \"{}\"", response.code, response.message)
+                val error: Either<ClashAPIError, ClientError> = deserialize(response.body?.string() ?: "")
 
-            when (it.code) {
-                400 -> ClashAPIError.BadRequest(it.message).left()
-                403 -> ClashAPIError.Forbidden(it.message).left()
-                404 -> ClashAPIError.NotFound(it.message).left()
-                429 -> ClashAPIError.TooManyRequests(it.message).left()
-                500 -> ClashAPIError.InternalServerError(it.message).left()
-                503 -> ClashAPIError.ServiceUnavailable(it.message).left()
-                else -> ClashAPIError.Unknown(it.message).left()
+                when (response.code) {
+                    400 -> error.flatMap { ClashAPIError.BadRequest(response.message, it).left() }
+                    403 -> error.flatMap { ClashAPIError.Forbidden(response.message, it).left() }
+                    404 -> error.flatMap { ClashAPIError.NotFound(response.message, it).left() }
+                    429 -> error.flatMap { ClashAPIError.TooManyRequests(response.message, it).left() }
+                    500 -> error.flatMap { ClashAPIError.InternalServerError(response.message, it).left() }
+                    503 -> error.flatMap { ClashAPIError.ServiceUnavailable(response.message, it).left() }
+                    else -> error.flatMap { ClashAPIError.Unknown(response.message, it).left() }
+                }
             }
         }
-    }
 
     /**
      * Deserialize the response body.
@@ -167,7 +183,7 @@ class ClashAPI(private val token: String) : Logging by LoggingImpl<ClashAPI>() {
      * @return [Either.Right] with the response if successful, [Either.Left] with an error otherwise.
      */
     private fun get(endpoint: String): Mono<Either<ClashAPIError, Response>> {
-        log.trace("Making GET request to {}", endpoint)
+        log.trace("Making GET request to \"{}\"", endpoint)
 
         val call: Call = http.newCall(baseRequest(endpoint).build())
 

--- a/src/main/kotlin/tech/ixirsii/klash/error/ClashAPIError.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/error/ClashAPIError.kt
@@ -30,49 +30,62 @@
 
 package tech.ixirsii.klash.error
 
+import tech.ixirsii.klash.types.error.ClientError
+
 /**
  * Represents an error returned by the Clash of Clans API.
  *
  * @author Ixirsii <ixirsii@ixirsii.tech>
  */
-sealed class ClashAPIError(message: String): Exception(message) {
+sealed interface ClashAPIError {
+    /**
+     * The error message.
+     */
+    val message: String
+
+    /**
+     *  The client error.
+     */
+    val error: ClientError?
+
     /**
      * 400 Bad Request error.
      */
-    class BadRequest(message: String): ClashAPIError(message)
+    data class BadRequest(override val message: String, override val error: ClientError) : ClashAPIError
 
     /**
      * Deserialization error.
      */
-    class DeserializationError(message: String): ClashAPIError(message)
+    data class DeserializationError(override val message: String, override val error: ClientError? = null) :
+        ClashAPIError
 
     /**
      * 403 Forbidden error.
      */
-    class Forbidden(message: String): ClashAPIError(message)
+    data class Forbidden(override val message: String, override val error: ClientError) : ClashAPIError
 
     /**
      * 404 Not Found error.
      */
-    class NotFound(message: String): ClashAPIError(message)
+    data class NotFound(override val message: String, override val error: ClientError) : ClashAPIError
 
     /**
      * 429 Too Many Requests error.
      */
-    class TooManyRequests(message: String): ClashAPIError(message)
+    data class TooManyRequests(override val message: String, override val error: ClientError) : ClashAPIError
 
     /**
      * 500 Internal Server Error error.
      */
-    class InternalServerError(message: String): ClashAPIError(message)
+    data class InternalServerError(override val message: String, override val error: ClientError) : ClashAPIError
 
     /**
      * 503 Service Unavailable error.
      */
-    class ServiceUnavailable(message: String): ClashAPIError(message)
+    data class ServiceUnavailable(override val message: String, override val error: ClientError) : ClashAPIError
 
     /**
      * Unknown error.
      */
-    class Unknown(message: String): ClashAPIError(message)
+    data class Unknown(override val message: String, override val error: ClientError) : ClashAPIError
 }

--- a/src/main/kotlin/tech/ixirsii/klash/error/ClashAPIError.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/error/ClashAPIError.kt
@@ -30,8 +30,6 @@
 
 package tech.ixirsii.klash.error
 
-import tech.ixirsii.klash.types.error.ClientError
-
 /**
  * Represents an error returned by the Clash of Clans API.
  *
@@ -43,49 +41,104 @@ sealed interface ClashAPIError {
      */
     val message: String
 
-    /**
-     *  The client error.
-     */
-    val error: ClientError?
+    sealed interface ClientError : ClashAPIError {
+        /**
+         *  The client error.
+         */
+        val error: tech.ixirsii.klash.types.error.ClientError
 
-    /**
-     * 400 Bad Request error.
-     */
-    data class BadRequest(override val message: String, override val error: ClientError) : ClashAPIError
+        /**
+         * 400 Bad Request error.
+         *
+         * @property message The error message.
+         * @property error The client error.
+         * @author Ixirsii <ixirsii@ixirsii.tech>
+         */
+        data class BadRequest(
+            override val message: String,
+            override val error: tech.ixirsii.klash.types.error.ClientError,
+        ) : ClientError
+
+        /**
+         * 403 Forbidden error.
+         *
+         * @property message The error message.
+         * @property error The client error.
+         * @author Ixirsii <ixirsii@ixirsii.tech>
+         */
+        data class Forbidden(
+            override val message: String,
+            override val error: tech.ixirsii.klash.types.error.ClientError,
+        ) : ClientError
+
+        /**
+         * 404 Not Found error.
+         *
+         * @property message The error message.
+         * @property error The client error.
+         * @author Ixirsii <ixirsii@ixirsii.tech>
+         */
+        data class NotFound(
+            override val message: String,
+            override val error: tech.ixirsii.klash.types.error.ClientError,
+        ) : ClientError
+
+        /**
+         * 429 Too Many Requests error.
+         *
+         * @property message The error message.
+         * @property error The client error.
+         * @author Ixirsii <ixirsii@ixirsii.tech>
+         */
+        data class TooManyRequests(
+            override val message: String,
+            override val error: tech.ixirsii.klash.types.error.ClientError,
+        ) : ClientError
+
+        /**
+         * 500 Internal Server Error error.
+         *
+         * @property message The error message.
+         * @property error The client error.
+         * @author Ixirsii <ixirsii@ixirsii.tech>
+         */
+        data class InternalServerError(
+            override val message: String,
+            override val error: tech.ixirsii.klash.types.error.ClientError,
+        ) :
+            ClientError
+
+        /**
+         * 503 Service Unavailable error.
+         *
+         * @property message The error message.
+         * @property error The client error.
+         * @author Ixirsii <ixirsii@ixirsii.tech>
+         */
+        data class ServiceUnavailable(
+            override val message: String,
+            override val error: tech.ixirsii.klash.types.error.ClientError,
+        ) :
+            ClientError
+
+        /**
+         * Unknown error.
+         *
+         * @property message The error message.
+         * @property error The client error.
+         * @author Ixirsii <ixirsii@ixirsii.tech>
+         */
+        data class Unknown(
+            override val message: String,
+            override val error: tech.ixirsii.klash.types.error.ClientError,
+        ) : ClientError
+    }
 
     /**
      * Deserialization error.
+     *
+     * @property message The error message.
+     * @author Ixirsii <ixirsii@ixirsii.tech>
      */
-    data class DeserializationError(override val message: String, override val error: ClientError? = null) :
-        ClashAPIError
-
-    /**
-     * 403 Forbidden error.
-     */
-    data class Forbidden(override val message: String, override val error: ClientError) : ClashAPIError
-
-    /**
-     * 404 Not Found error.
-     */
-    data class NotFound(override val message: String, override val error: ClientError) : ClashAPIError
-
-    /**
-     * 429 Too Many Requests error.
-     */
-    data class TooManyRequests(override val message: String, override val error: ClientError) : ClashAPIError
-
-    /**
-     * 500 Internal Server Error error.
-     */
-    data class InternalServerError(override val message: String, override val error: ClientError) : ClashAPIError
-
-    /**
-     * 503 Service Unavailable error.
-     */
-    data class ServiceUnavailable(override val message: String, override val error: ClientError) : ClashAPIError
-
-    /**
-     * Unknown error.
-     */
-    data class Unknown(override val message: String, override val error: ClientError) : ClashAPIError
+    data class DeserializationError(override val message: String) : ClashAPIError
 }

--- a/src/main/kotlin/tech/ixirsii/klash/logging/LoggingImpl.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/logging/LoggingImpl.kt
@@ -35,10 +35,10 @@ import org.slf4j.Logger
 /**
  * Implementation that injects a logger into a class.
  *
+ * @property log SLF4J logger.
  * @author Ixirsii <ixirsii@ixirsii.tech>
  */
-class LoggingImpl(logger: Logger) : Logging {
-    override val log: Logger = logger
+class LoggingImpl(override val log: Logger) : Logging {
 
     companion object {
         /**

--- a/src/main/kotlin/tech/ixirsii/klash/types/BadgeURLs.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/BadgeURLs.kt
@@ -35,20 +35,10 @@ import kotlinx.serialization.Serializable
 /**
  * Clan badge URLs.
  *
+ * @property small Small badge URL.
+ * @property medium Medium badge URL.
+ * @property large Large badge URL.
  * @author Ixirsii <ixirsii@ixirsii.tech>
  */
 @Serializable
-data class BadgeURLs(
-    /**
-     * Small badge URL.
-     */
-    val small: String = "",
-    /**
-     * Medium badge URL.
-     */
-    val medium: String = "",
-    /**
-     * Large badge URL.
-     */
-    val large: String = "",
-)
+data class BadgeURLs(val small: String = "", val medium: String = "", val large: String = "")

--- a/src/main/kotlin/tech/ixirsii/klash/types/Cursors.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/Cursors.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Ryan Porterfield 2023.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of KlashAPI nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.ixirsii.klash.types
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Cursors(
+    val after: String = "",
+    val before: String = "",
+)

--- a/src/main/kotlin/tech/ixirsii/klash/types/Cursors.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/Cursors.kt
@@ -32,6 +32,13 @@ package tech.ixirsii.klash.types
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Pagination cursor.
+ *
+ * @property after After cursor.
+ * @property before Before cursor.
+ * @author Ixirsii <ixirsii@ixirsii.tech>
+ */
 @Serializable
 data class Cursors(
     val after: String = "",

--- a/src/main/kotlin/tech/ixirsii/klash/types/Paging.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/Paging.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Ryan Porterfield 2023.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of KlashAPI nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.ixirsii.klash.types
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Paging(val cursors: Cursors)

--- a/src/main/kotlin/tech/ixirsii/klash/types/Paging.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/Paging.kt
@@ -32,5 +32,11 @@ package tech.ixirsii.klash.types
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Pagination cursor.
+ *
+ * @property cursors Cursors object.
+ * @author Ixirsii <ixirsii@ixirsii.tech>
+ */
 @Serializable
 data class Paging(val cursors: Cursors)

--- a/src/main/kotlin/tech/ixirsii/klash/types/cwl/ClanWarLeagueClan.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/cwl/ClanWarLeagueClan.kt
@@ -37,29 +37,18 @@ import tech.ixirsii.klash.types.BadgeURLs
 /**
  * Clan in a Clan War League.
  *
+ * @property badgeURLs Clan badge URLs.
+ * @property clanLevel Clan level.
+ * @property members Clan members.
+ * @property name Clan name.
+ * @property tag Clan tag.
  * @author Ixirsii <ixirsii@ixirsii.tech>
  */
 @Serializable
 data class ClanWarLeagueClan(
-    /**
-     * Clan badge URLs.
-     */
-    @SerialName("badgeUrls")
-    val badgeURLs: BadgeURLs,
-    /**
-     * Clan level.
-     */
+    @SerialName("badgeUrls") val badgeURLs: BadgeURLs,
     val clanLevel: Int,
-    /**
-     * Clan members.
-     */
     val members: List<ClanWarLeagueMember>,
-    /**
-     * Clan name.
-     */
     val name: String,
-    /**
-     * Clan tag.
-     */
     val tag: String,
 )

--- a/src/main/kotlin/tech/ixirsii/klash/types/cwl/ClanWarLeagueGroup.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/cwl/ClanWarLeagueGroup.kt
@@ -36,29 +36,19 @@ import kotlinx.serialization.Serializable
 /**
  * Clan War League group.
  *
+ * @property clans Clans in CWL group.
+ * @property rounds CWL group rounds.
+ * @property season CWL group season.
+ * @property state CWL group state.
+ * @property tag CWL group tag. This seems to always be null.
  * @author Ixirsii <ixirsii@ixirsii.tech>
  */
 @Serializable
 data class ClanWarLeagueGroup(
-    /**
-     * Clans in CWL group.
-     */
     val clans: List<ClanWarLeagueClan>,
-    /**
-     * CWL group rounds.
-     */
     val rounds: List<ClanWarLeagueRound>,
-    /**
-     * CWL group season.
-     */
     val season: String,
-    /**
-     * CWL group state.
-     */
     val state: State,
-    /**
-     * CWL group tag. This seems to always be null.
-     */
     val tag: String = "",
 ) {
     /**
@@ -70,21 +60,25 @@ data class ClanWarLeagueGroup(
          */
         @SerialName("groupNotFound")
         GROUP_NOT_FOUND,
+
         /**
          * Not in war.
          */
         @SerialName("notInWar")
         NOT_IN_WAR,
+
         /**
          * Preparation day.
          */
         @SerialName("preparation")
         PREPARATION,
+
         /**
          * War day.
          */
         @SerialName("war")
         WAR,
+
         /**
          * CWL ended.
          */

--- a/src/main/kotlin/tech/ixirsii/klash/types/cwl/ClanWarLeagueMember.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/cwl/ClanWarLeagueMember.kt
@@ -35,20 +35,10 @@ import kotlinx.serialization.Serializable
 /**
  * Member of a clan in a Clan War League.
  *
+ * @property name Player name.
+ * @property tag Player tag.
+ * @property townHallLevel Town hall level.
  * @author Ixirsii <ixirsii@ixirsii.tech>
  */
 @Serializable
-data class ClanWarLeagueMember(
-    /**
-     * Player name.
-     */
-    val name: String,
-    /**
-     * Player tag.
-     */
-    val tag: String,
-    /**
-     * Town hall level.
-     */
-    val townHallLevel: Int,
-)
+data class ClanWarLeagueMember(val name: String, val tag: String, val townHallLevel: Int)

--- a/src/main/kotlin/tech/ixirsii/klash/types/cwl/ClanWarLeagueRound.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/cwl/ClanWarLeagueRound.kt
@@ -35,12 +35,8 @@ import kotlinx.serialization.Serializable
 /**
  * Represents a clan war league round.
  *
+ * @property warTags War tags in this round of CWL.
  * @author Ixirsii <ixirsii@ixirsii.tech>
  */
 @Serializable
-data class ClanWarLeagueRound(
-    /**
-     * War tags in this round of CWL.
-     */
-    val warTags: List<String>,
-)
+data class ClanWarLeagueRound(val warTags: List<String>)

--- a/src/main/kotlin/tech/ixirsii/klash/types/error/ClientError.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/error/ClientError.kt
@@ -35,20 +35,10 @@ import kotlinx.serialization.Serializable
 /**
  * Clash of Clans API request error.
  *
+ * @property reason Error reason.
+ * @property message Error message.
+ * @property type Error type.
  * @author Ixirsii <ixirsii@ixirsii.tech>
  */
 @Serializable
-data class ClientError(
-    /**
-     * Error reason.
-     */
-    val reason: String = "",
-    /**
-     * Error message.
-     */
-    val message: String = "",
-    /**
-     * Error type.
-     */
-    val type: String = "",
-)
+data class ClientError(val reason: String = "", val message: String = "", val type: String = "")

--- a/src/main/kotlin/tech/ixirsii/klash/types/war/Result.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/war/Result.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Ryan Porterfield 2023.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of KlashAPI nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.ixirsii.klash.types.war
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class Result {
+    @SerialName("lose")
+    LOSE,
+    @SerialName("win")
+    WIN,
+    @SerialName("tie")
+    TIE
+}

--- a/src/main/kotlin/tech/ixirsii/klash/types/war/Result.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/war/Result.kt
@@ -32,13 +32,26 @@ package tech.ixirsii.klash.types.war
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import tech.ixirsii.klash.types.war.Result.LOSE
+import tech.ixirsii.klash.types.war.Result.TIE
+import tech.ixirsii.klash.types.war.Result.WIN
 
+/**
+ * Clan war result.
+ *
+ * @property LOSE Lost the war.
+ * @property WIN Won the war.
+ * @property TIE Tied the war.
+ * @author Ixirsii <ixirsii@ixirsii.tech>
+ */
 @Serializable
 enum class Result {
     @SerialName("lose")
     LOSE,
+
     @SerialName("win")
     WIN,
+
     @SerialName("tie")
     TIE
 }

--- a/src/main/kotlin/tech/ixirsii/klash/types/war/State.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/war/State.kt
@@ -32,71 +32,61 @@ package tech.ixirsii.klash.types.war
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import tech.ixirsii.klash.types.war.State.ACCESS_DENIED
+import tech.ixirsii.klash.types.war.State.CLAN_NOT_FOUND
+import tech.ixirsii.klash.types.war.State.ENDED
+import tech.ixirsii.klash.types.war.State.ENTER_WAR
+import tech.ixirsii.klash.types.war.State.IN_MATCHMAKING
+import tech.ixirsii.klash.types.war.State.IN_WAR
+import tech.ixirsii.klash.types.war.State.MATCHED
+import tech.ixirsii.klash.types.war.State.NOT_IN_WAR
+import tech.ixirsii.klash.types.war.State.PREPARATION
+import tech.ixirsii.klash.types.war.State.WAR
 
 /**
  * Clan war state.
  *
+ * @property CLAN_NOT_FOUND Clan not found.
+ * @property ACCESS_DENIED Access denied.
+ * @property NOT_IN_WAR Not in war.
+ * @property IN_MATCHMAKING Matchmaking.
+ * @property ENTER_WAR Enter war (?).
+ * @property MATCHED Matched.
+ * @property PREPARATION Preparation.
+ * @property WAR War (?).
+ * @property IN_WAR In war.
+ * @property ENDED War ended.
  * @author Ixirsii <ixirsii@ixirsii.tech>
  */
 @Serializable
 enum class State {
-    /**
-     * Clan not found.
-     */
     @SerialName("clanNotFound")
     CLAN_NOT_FOUND,
 
-    /**
-     * Access denied.
-     */
     @SerialName("accessDenied")
     ACCESS_DENIED,
 
-    /**
-     * Not in war.
-     */
     @SerialName("notInWar")
     NOT_IN_WAR,
 
-    /**
-     * War ended.
-     */
     @SerialName("inMatchmaking")
     IN_MATCHMAKING,
 
-    /**
-     * Enter war(?).
-     */
     @SerialName("enterWar")
     ENTER_WAR,
 
-    /**
-     * Matched.
-     */
     @SerialName("matched")
     MATCHED,
 
-    /**
-     * Preparation.
-     */
     @SerialName("preparation")
     PREPARATION,
 
-    /**
-     * War (?).
-     */
     @SerialName("war")
     WAR,
 
-    /**
-     * In war.
-     */
     @SerialName("inWar")
     IN_WAR,
 
-    /**
-     * War ended.
-     */
     @SerialName("warEnded")
     ENDED
 }

--- a/src/main/kotlin/tech/ixirsii/klash/types/war/War.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/war/War.kt
@@ -37,44 +37,24 @@ import java.time.ZonedDateTime
 /**
  * Clan War League war.
  *
+ * @property clan First clan in war.
+ * @property endTime War end time.
+ * @property opponent Second clan in war.
+ * @property preparationStartTime Preparation start time.
+ * @property startTime Start time (?).
+ * @property state War state.
+ * @property teamSize Team size.
+ * @property warStartTime War start time (?).
  * @author Ixirsii <ixirsii@ixirsii.tech>
  */
 @Serializable
 data class War(
-    /**
-     * First clan in war.
-     */
     val clan: WarClan,
-    /**
-     * War end time.
-     */
-    @Serializable(with = ZonedDateTimeSerializer::class)
-    val endTime: ZonedDateTime,
-    /**
-     * Second clan in war.
-     */
+    @Serializable(with = ZonedDateTimeSerializer::class) val endTime: ZonedDateTime,
     val opponent: WarClan,
-    @Serializable(with = ZonedDateTimeSerializer::class)
-    /**
-     * Preparation start time.
-     */
-    val preparationStartTime: ZonedDateTime,
-    @Serializable(with = ZonedDateTimeSerializer::class)
-    /**
-     * Start time (?).
-     */
-    val startTime: ZonedDateTime,
-    /**
-     * War state.
-     */
+    @Serializable(with = ZonedDateTimeSerializer::class) val preparationStartTime: ZonedDateTime,
+    @Serializable(with = ZonedDateTimeSerializer::class) val startTime: ZonedDateTime,
     val state: State,
-    /**
-     * Team size.
-     */
     val teamSize: Int,
-    /**
-     * War start time (?).
-     */
-    @Serializable(with = ZonedDateTimeSerializer::class)
-    val warStartTime: ZonedDateTime,
+    @Serializable(with = ZonedDateTimeSerializer::class) val warStartTime: ZonedDateTime,
 )

--- a/src/main/kotlin/tech/ixirsii/klash/types/war/WarClan.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/war/WarClan.kt
@@ -37,41 +37,24 @@ import tech.ixirsii.klash.types.BadgeURLs
 /**
  * Clan war clan.
  *
+ * @property attacks Number of attacks made.
+ * @property badgeURLs Clan badge URLs.
+ * @property clanLevel Clan level.
+ * @property destructionPercentage Average destruction percentage.
+ * @property members War members.
+ * @property name Clan name.
+ * @property stars Total number of attack stars.
+ * @property tag Clan tag.
  * @author Ixirsii <ixirsii@ixirsii.tech>
  */
 @Serializable
 data class WarClan(
-    /**
-     * Number of attacks made.
-     */
     val attacks: Int,
-    /**
-     * Clan badge URLs.
-     */
-    @SerialName("badgeUrls")
-    val badgeURLs: BadgeURLs,
-    /**
-     * Clan level.
-     */
+    @SerialName("badgeUrls") val badgeURLs: BadgeURLs,
     val clanLevel: Int,
-    /**
-     * Average destruction percentage.
-     */
     val destructionPercentage: Double,
-    /**
-     * War members.
-     */
     val members: List<WarClanMember>,
-    /**
-     * Clan name.
-     */
     val name: String,
-    /**
-     * Total number of attack stars.
-     */
     val stars: Int,
-    /**
-     * Clan tag.
-     */
-    val tag: String
+    val tag: String,
 )

--- a/src/main/kotlin/tech/ixirsii/klash/types/war/WarClanMember.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/war/WarClanMember.kt
@@ -36,37 +36,22 @@ import kotlinx.serialization.Serializable
 /**
  * Clan war member.
  *
+ * @property attacks Attacks made by member.
+ * @property bestOpponentAttack Best attack against member.
+ * @property mapPosition Position on the map.
+ * @property name Member name.
+ * @property opponentAttacks How many attacks were made against the member.
+ * @property tag Player tag.
+ * @property townHallLevel Town hall level.
  * @author Ixirsii <ixirsii@ixirsii.tech>
  */
 @Serializable
 data class WarClanMember(
-    /**
-     * Attacks made by member.
-     */
     val attacks: List<WarClanMemberAttack> = emptyList(),
-    /**
-     * Best attack against member.
-     */
     val bestOpponentAttack: WarClanMemberAttack? = null,
-    /**
-     * Position on the map.
-     */
     val mapPosition: Int,
-    /**
-     * Member name.
-     */
     val name: String,
-    /**
-     * How many attacks were made against the member.
-     */
     val opponentAttacks: Int,
-    /**
-     * Player tag.
-     */
     val tag: String,
-    /**
-     * Town hall level.
-     */
-    @SerialName("townhallLevel")
-    val townHallLevel: Int,
+    @SerialName("townhallLevel") val townHallLevel: Int,
 )

--- a/src/main/kotlin/tech/ixirsii/klash/types/war/WarClanMemberAttack.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/war/WarClanMemberAttack.kt
@@ -35,32 +35,20 @@ import kotlinx.serialization.Serializable
 /**
  * Clan war attack.
  *
+ * @property attackerTag Attacker's player tag.
+ * @property defenderTag Defender's player tag.
+ * @property destructionPercentage Destruction percentage.
+ * @property duration Duration in seconds.
+ * @property order Attack order in war.
+ * @property stars Stars earned.
  * @author Ixirsii <ixirsii@ixirsii.tech>
  */
 @Serializable
 data class WarClanMemberAttack(
-    /**
-     * Attacker's player tag.
-     */
     val attackerTag: String,
-    /**
-     * Defender's player tag.
-     */
     val defenderTag: String,
-    /**
-     * Destruction percentage.
-     */
     val destructionPercentage: Double,
-    /**
-     * Duration in seconds.
-     */
     val duration: Int,
-    /**
-     * Attack order in war.
-     */
     val order: Int,
-    /**
-     * Stars earned.
-     */
     val stars: Int,
 )

--- a/src/main/kotlin/tech/ixirsii/klash/types/war/WarLog.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/war/WarLog.kt
@@ -33,6 +33,13 @@ package tech.ixirsii.klash.types.war
 import kotlinx.serialization.Serializable
 import tech.ixirsii.klash.types.Paging
 
+/**
+ * Clan war log.
+ *
+ * @property items List of war log entries.
+ * @property paging Paging information.
+ * @author Ixirsii <ixirsii@ixirsii.tech>
+ */
 @Serializable
 data class WarLog (
     val items: List<WarLogEntry>,

--- a/src/main/kotlin/tech/ixirsii/klash/types/war/WarLog.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/war/WarLog.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Ryan Porterfield 2023.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of KlashAPI nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.ixirsii.klash.types.war
+
+import kotlinx.serialization.Serializable
+import tech.ixirsii.klash.types.Paging
+
+@Serializable
+data class WarLog (
+    val items: List<WarLogEntry>,
+    val paging: Paging,
+)

--- a/src/main/kotlin/tech/ixirsii/klash/types/war/WarLogClan.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/war/WarLogClan.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Ryan Porterfield 2023.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of KlashAPI nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.ixirsii.klash.types.war
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import tech.ixirsii.klash.types.BadgeURLs
+
+@Serializable
+data class WarLogClan(
+    val attacks: Int = 0,
+    @SerialName("badgeUrls")
+    val badgeUrls: BadgeURLs? = null,
+    val clanLevel: Int = 0,
+    val destructionPercentage: Double = 0.0,
+    val expEarned: Int = 0,
+    val name: String = "",
+    val stars: Int = 0,
+    val tag: String = "",
+)

--- a/src/main/kotlin/tech/ixirsii/klash/types/war/WarLogClan.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/war/WarLogClan.kt
@@ -34,11 +34,23 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import tech.ixirsii.klash.types.BadgeURLs
 
+/**
+ * War log entry clan.
+ *
+ * @property attacks Attacks made by clan.
+ * @property badgeUrls Clan badge URLs.
+ * @property clanLevel Clan level.
+ * @property destructionPercentage Average destruction percentage.
+ * @property expEarned Experience earned.
+ * @property name Clan name.
+ * @property stars Total number of attack stars.
+ * @property tag Clan tag.
+ * @author Ixirsii <ixirsii@ixirsii.tech>
+ */
 @Serializable
 data class WarLogClan(
     val attacks: Int = 0,
-    @SerialName("badgeUrls")
-    val badgeUrls: BadgeURLs? = null,
+    @SerialName("badgeUrls") val badgeUrls: BadgeURLs? = null,
     val clanLevel: Int = 0,
     val destructionPercentage: Double = 0.0,
     val expEarned: Int = 0,

--- a/src/main/kotlin/tech/ixirsii/klash/types/war/WarLogEntry.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/war/WarLogEntry.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Ryan Porterfield 2023.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of KlashAPI nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package tech.ixirsii.klash.types.war
+
+import kotlinx.serialization.Serializable
+import tech.ixirsii.klash.serialize.ZonedDateTimeSerializer
+import java.time.ZonedDateTime
+
+@Serializable
+data class WarLogEntry(
+    val attacksPerMember: Int,
+    val clan: WarLogClan? = null,
+    @Serializable(with = ZonedDateTimeSerializer::class)
+    val endTime: ZonedDateTime,
+    val opponent: WarLogClan? = null,
+    val result: Result? = null,
+    val teamSize: Int,
+)

--- a/src/main/kotlin/tech/ixirsii/klash/types/war/WarLogEntry.kt
+++ b/src/main/kotlin/tech/ixirsii/klash/types/war/WarLogEntry.kt
@@ -34,12 +34,21 @@ import kotlinx.serialization.Serializable
 import tech.ixirsii.klash.serialize.ZonedDateTimeSerializer
 import java.time.ZonedDateTime
 
+/**
+ * War log entry.
+ *
+ * @property attacksPerMember Number of attacks per member.
+ * @property clan First clan.
+ * @property endTime End time.
+ * @property opponent Second clan.
+ * @property result War result.
+ * @property teamSize Team size.
+ */
 @Serializable
 data class WarLogEntry(
     val attacksPerMember: Int,
     val clan: WarLogClan? = null,
-    @Serializable(with = ZonedDateTimeSerializer::class)
-    val endTime: ZonedDateTime,
+    @Serializable(with = ZonedDateTimeSerializer::class) val endTime: ZonedDateTime,
     val opponent: WarLogClan? = null,
     val result: Result? = null,
     val teamSize: Int,

--- a/src/test/kotlin/tech/ixirsii/klash/client/ClashAPITest.kt
+++ b/src/test/kotlin/tech/ixirsii/klash/client/ClashAPITest.kt
@@ -72,7 +72,7 @@ internal class ClashAPITest {
         }.onLeft {
                 when (it) {
                     // Succeed test on NotFound because CWL may not be active when test is run
-                    is ClashAPIError.NotFound -> Unit
+                    is ClashAPIError.ClientError.NotFound -> Unit
                     else -> fail("Unexpected error \"$it\"")
                 }
             }


### PR DESCRIPTION
- Add war log endpoint
- Add war log types
- Add war log endpoint tests
- Add documentation
- Refactor existing documentation to put property documentation at class level @property tags
- Refactor `ClashAPIError` to
  - Be a sealed interface instead of a class which extends Exception
  - Have a nested sealed interface `ClientError`
- Refactor Clash API client errors into `ClashAPIError.ClientError`
- `ClashAPIError.ClientError` has a property `error: ClientError` which is the deserialized error from the Clash API
- Refactor tests to print the `ClashAPIError` on left failure